### PR TITLE
reload nginx configuration in a portable way

### DIFF
--- a/certbot-ocsp-fetcher
+++ b/certbot-ocsp-fetcher
@@ -485,7 +485,7 @@ print_and_handle_result() {
 reload_webserver() {
   for lineage_name in "${!lineages_processed[@]}"; do
     if [[ ${lineages_processed["${lineage_name}"]} == updated ]]; then
-      if service nginx reload >&3 2>&1; then
+      if nginx -s reload >&3 2>&1; then
         # The last line includes a leading space, to workaround the lack of the
         # `-n` flag in later versions of `column`.
         local -r nginx_status=$'\n\n \t'"nginx reloaded"


### PR DESCRIPTION
The service command isn't portable across operating systems. It exists
on Debian for backwards compatibility and to abstract over different
init systems. A lot of other operating systems either never had this
utility or removed it part of fully moving to systemd. Most downstream
nginx.service unit files simply use this utility anyway. The upstream
unit file used in their own packages is actually missing the
configuration validation so it won't report errors properly.