### PR TITLE
Sandbox Systemd unit file

### DIFF
--- a/systemd-units/certbot-ocsp-fetcher.service
+++ b/systemd-units/certbot-ocsp-fetcher.service
@@ -4,10 +4,56 @@ Description=Fetch OCSP responses for all certificates issued with Certbot
 [Service]
 Type=oneshot
 
-# When systemd v244+ is available, this should be uncommented to enable retries
-# on failure.
-# Restart=on-failure
+Restart=on-failure
 
 User=root
 Group=root
-ExecStart=/usr/local/bin/certbot-ocsp-fetcher
+ExecStart=/usr/local/bin/certbot-ocsp-fetcher -w -o /etc/nginx/ocsp-cache
+ExecStartPost=systemctl reload nginx.service
+
+RestartSec=5
+PrivateDevices=true
+PrivateTmp=yes
+PrivateUsers=yes
+PrivateIPC=true
+
+NoNewPrivileges=true
+LockPersonality=true
+
+CapabilityBoundingSet=
+ProtectHome=yes
+ProtectControlGroups=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectClock=true
+ProtectProc=invisible
+ProcSubset=pid
+ProtectHostname=true
+RemoveIPC=true
+
+RestrictAddressFamilies=AF_INET6 AF_INET AF_UNIX
+MemoryDenyWriteExecute=true
+RestrictRealtime=true
+RestrictNamespaces=true
+RestrictSUIDSGID=true
+
+DevicePolicy=strict
+DeviceAllow=/dev/random r
+DeviceAllow=/dev/urandom r
+DeviceAllow=/dev/stdin r
+DeviceAllow=/dev/stdout r
+DeviceAllow=/dev/null w
+
+ProtectSystem=strict
+InaccessiblePaths=/root/
+ReadOnlyPaths=/etc/letsencrypt
+ReadWritePaths=/etc/nginx/ocsp-cache
+UMask=0077
+
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@clock @debug @module @mount @reboot @swap @resources @cpu-emulation @raw-io @obsolete @keyring @privileged
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Restrict privileges for certbot-ocsp-fetcher in the Systemd unit file.
Running "systemd-analyze security certbot-ocsp-fetcher.service" now
returns a score of "1.4 OK".