### PR TITLE
Add SELinux support

### DIFF
--- a/certbot-ocsp-fetcher
+++ b/certbot-ocsp-fetcher
@@ -573,7 +573,7 @@ fetch_ocsp_response() {
 
   # If arrived here status was good, so move OCSP staple file to definitive
   # folder
-  mv "${temp_output_dir}/${lineage_name}.der" "${OUTPUT_DIR}/"
+  mv -Z "${temp_output_dir}/${lineage_name}.der" "${OUTPUT_DIR}/"
 
   lineages_processed["${lineage_name}"]=updated
 }

--- a/certbot-ocsp-fetcher
+++ b/certbot-ocsp-fetcher
@@ -573,7 +573,7 @@ fetch_ocsp_response() {
 
   # If arrived here status was good, so move OCSP staple file to definitive
   # folder
-  mv -Z "${temp_output_dir}/${lineage_name}.der" "${OUTPUT_DIR}/"
+  mv --context "${temp_output_dir}/${lineage_name}.der" "${OUTPUT_DIR}/"
 
   lineages_processed["${lineage_name}"]=updated
 }


### PR DESCRIPTION
Since the staples are created in tmpfs, they will have the user_tmp_t context which will break nginx when it tries to reload. This fixes the problem assuming the policies set the output dir to be labeled as httpd_config_t